### PR TITLE
fix(deps): use cooklang without bundled_units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,16 +105,11 @@ dependencies = [
  "enum-map",
  "finl_unicode",
  "indexmap",
- "prettyplease",
- "proc-macro2",
- "quote",
  "serde",
  "serde_yaml",
  "smallvec",
  "strum",
- "syn",
  "thiserror",
- "toml",
  "tracing",
  "unicase",
  "unicode-width",
@@ -647,16 +642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,15 +784,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1041,47 +1017,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1355,15 +1290,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,11 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 
 # Cooklang
-cooklang = "0.18"
+# We only parse and diagnose: the parser, model, error types and aisle config.
+# bundled_units (on by default) builds the unit database and is unused here -
+# and because cargo unifies features, enabling it forced it on every consumer
+# that shares our cooklang dependency.
+cooklang = { version = "0.18", default-features = false, features = ["aisle"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Fallout from cooklang/cookcli#366.

## The problem

We depend on `cooklang` with **default features**, and `cooklang`'s defaults include `bundled_units` — the generated unit database (which drags in a `toml`/`syn`/`prettyplease`/`quote` codegen chain).

We do not use it. The language server only parses and diagnoses:

- `cooklang::parser::PullParser`
- `cooklang::model::{Ingredient, Cookware, Timer, Content}`
- `cooklang::error::{Severity, SourceDiag}`
- `cooklang::aisle::parse_lenient`

No converter, no unit conversion, no shopping list, no pantry.

Worse, because **cargo unifies features across the whole graph**, enabling `bundled_units` here forced it on for *every* consumer sharing our `cooklang` dependency. CookCLI turned out to be silently relying on that — it never declared `bundled_units` itself, and gating the language server out of its build changed recipe output (`"unit": "c"` → `"cups"`, `scalable` flipping). That is now fixed on their side in cooklang/cookcli#371, so this change is safe to make.

## The change

```toml
cooklang = { version = "0.18", default-features = false, features = ["aisle"] }
```

Declare only what we use. **127 → 120 crates.**

## Behaviour note worth a second opinion

Without `bundled_units` the parser has no unit database. If cooklang emits any unit-aware diagnostics (e.g. warning on an unknown unit), those would stop appearing in the editor. I found no such usage on our side and the test suite is unchanged, but you know the parser better than I do — if unit validation is something we *want* to surface as a diagnostic, then the right fix is to keep `bundled_units` and have consumers declare it explicitly instead.

## Verification
- `cargo build` — clean
- `cargo test` — 3 suites pass
- `cargo clippy` — 0 issues

(`cargo fmt --check` reports diffs, but they are pre-existing and in files this PR does not touch — rustfmt version drift. Left alone rather than bundling a reformat into a dependency change.)
