### PR TITLE
ci: add test and release workflows (incl. cargo publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 0.2.5)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (verify only: no commit, tag, release or publish)'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Required by crates-io-auth-action for OIDC trusted publishing.
+      id-token: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$VERSION' is not a semver version (e.g. 0.2.5)"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version_tag=v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Fail if the tag already exists
+        run: |
+          TAG="${{ steps.version.outputs.version_tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists"
+            exit 1
+          fi
+
+      - name: Update Cargo.toml version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "0,/^version = \".*\"/s//version = \"${VERSION}\"/" Cargo.toml
+          cargo update -p cooklang-language-server
+          grep -m1 '^version' Cargo.toml
+
+      - name: Verify
+        run: |
+          cargo fmt --check
+          cargo clippy --all-targets -- -D warnings
+          cargo test
+          cargo publish --dry-run
+
+      - name: Commit version bump
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): ${{ steps.version.outputs.version }}"
+          git push origin HEAD:main
+
+      - name: Create and push tag
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          TAG="${{ steps.version.outputs.version_tag }}"
+          git tag "${TAG}"
+          git push origin "${TAG}"
+
+      - name: Create GitHub release
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.version_tag }}
+          name: Release ${{ steps.version.outputs.version_tag }}
+          generate_release_notes: true
+
+      # Trusted publishing: no CARGO_REGISTRY_TOKEN secret needed, but the crate
+      # must have this repo + workflow registered as a Trusted Publisher on
+      # crates.io. Same setup as cooklang-rs and CookCLI.
+      - name: Authenticate to crates.io
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish to crates.io
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,51 @@
+name: Rust
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      # Catches packaging problems (missing files, bad metadata) before a
+      # release tries to publish, rather than after.
+      - name: Check the crate packages cleanly
+        run: cargo publish --dry-run

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -181,9 +181,7 @@ fn format_timer_hover(timer: &cooklang::model::Timer) -> String {
 mod tests {
     use super::*;
     use crate::document::Document;
-    use tower_lsp::lsp_types::{
-        Position, TextDocumentIdentifier, TextDocumentPositionParams, Url,
-    };
+    use tower_lsp::lsp_types::{Position, TextDocumentIdentifier, TextDocumentPositionParams, Url};
 
     fn hover_at(content: &str, cursor: usize) -> String {
         let doc = Document::new(

--- a/src/state.rs
+++ b/src/state.rs
@@ -224,7 +224,11 @@ carrot
         assert_eq!(milk.unwrap().category, "dairy");
 
         // Duplicate apple entries should be skipped (only one apple)
-        let apple_count = config.ingredients.iter().filter(|i| i.name == "apple").count();
+        let apple_count = config
+            .ingredients
+            .iter()
+            .filter(|i| i.name == "apple")
+            .count();
         assert_eq!(apple_count, 1);
     }
 }

--- a/src/utils/components.rs
+++ b/src/utils/components.rs
@@ -99,12 +99,18 @@ mod tests {
         assert_eq!(comps.len(), 1);
         assert_eq!(comps[0].kind, ComponentKind::Ingredient);
         assert_eq!(comps[0].name, "heavy whipping cream");
-        assert_eq!(&s[comps[0].span.start()..comps[0].span.end()], "@heavy whipping cream{1%cup}");
+        assert_eq!(
+            &s[comps[0].span.start()..comps[0].span.end()],
+            "@heavy whipping cream{1%cup}"
+        );
     }
 
     #[test]
     fn names_with_punctuation() {
-        assert_eq!(texts("Add @lady's fingers{20}."), vec!["@lady's fingers{20}"]);
+        assert_eq!(
+            texts("Add @lady's fingers{20}."),
+            vec!["@lady's fingers{20}"]
+        );
         assert_eq!(
             texts("Use @sun-dried tomatoes{1/2%cup}."),
             vec!["@sun-dried tomatoes{1/2%cup}"]


### PR DESCRIPTION
This repo had **no CI at all** — nothing built, tested or linted a PR — and **no `cargo publish` step**, so a "release" tagged a version that never reached crates.io. That is exactly what stalled the dependency chain in cooklang/cookcli#366: the tag and GitHub release existed, but downstream crates resolve from crates.io and could not see it.

## Two commits, deliberately split

**1. `style: cargo fmt`** — formatting only, 3 files, no behaviour change. `cargo fmt --check` currently fails on pre-existing drift, so without this the new workflow would land red on day one. Split out so it stays reviewable and the CI commit is honest.

**2. `ci: add test and release workflows`** — the actual change.

## `rust.yml` — on every push/PR to `main`

`cargo fmt --check` → `cargo clippy --all-targets -- -D warnings` → `cargo build` → `cargo test` → **`cargo publish --dry-run`**.

That last step is the one that would have caught this class of problem: packaging breakage now surfaces on a PR rather than when a release tries to publish.

## `release.yml` — `workflow_dispatch` with a version input

Bumps `Cargo.toml`, verifies (fmt/clippy/test/dry-run), commits, tags, cuts a GitHub release, and **publishes to crates.io**. Also:

- refuses to reuse an existing tag, rather than failing halfway through
- `dry_run` input that verifies everything without committing, tagging, releasing or publishing

## Auth — one thing you need to do

Publishing uses **OIDC trusted publishing** via `rust-lang/crates-io-auth-action@v1` (`id-token: write`), matching what `cooklang-rs` and CookCLI already do. That means no `CARGO_REGISTRY_TOKEN` secret — but it does require registering a Trusted Publisher for this crate on crates.io before the first automated release:

> crates.io → `cooklang-language-server` → Settings → Trusted Publishing → add
> repository `cooklang/cooklang-language-server`, workflow `release.yml`

Until that is configured, the publish step will fail on auth. Everything before it (verify/commit/tag/GitHub release) will still work, and `dry_run: true` is safe to exercise immediately.

If you would rather use a `CARGO_REGISTRY_TOKEN` secret instead, say so and I will swap the two auth steps out.

## Verification

Ran the exact CI commands locally against the toolchain CI uses (1.97), on a clean tree:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — 0 issues
- `cargo test` — 3 suites pass
- `cargo publish --dry-run` — packages cleanly (`Uploading cooklang-language-server v0.2.4`, aborted for dry run)

Refs cooklang/cookcli#366
